### PR TITLE
Update to v1.0.2 of standalone-soci-indexer

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -12,7 +12,7 @@ if [ -z "$IMAGE" ]; then
 fi
 
 # Download the binary from Buildkite's fork of https://github.com/CloudSnorkel/standalone-soci-indexer
-wget https://github.com/buildkite/standalone-soci-indexer/releases/download/v1.0.1-buildkite/standalone-soci-indexer
+wget https://github.com/buildkite/standalone-soci-indexer/releases/download/v1.0.2-buildkite/standalone-soci-indexer
 
 chmod +x standalone-soci-indexer
 


### PR DESCRIPTION
The binary was compiled by me, using a fresh checkout of upstreams v1.0.2 tag and no modifications.

v1.0.2 supports being points at ECR image manifests, which means this will work with:

* multi-arch images
* single-arch images generated with buildkit